### PR TITLE
Update DownloadActivity.java

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/DownloadActivity.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/DownloadActivity.java
@@ -369,7 +369,7 @@ public class DownloadActivity extends BaseActivity {
             this.extractMapFromZIP = extractMapFromZIP;
         }
 
-        abstract public Uri getDirectoryUri();
+        public abstract Uri getDirectoryUri();
 
         public int getOverwriteMessageId() {
             return overwriteMessageId;


### PR DESCRIPTION
The current method signature abstract public Uri getDirectoryUri(); in the codebase needs to have its modifiers reordered to comply with the Java Language Specification (JLS). According to the JLS guidelines, the correct order for method modifiers should be access level, followed by other modifiers such as abstract or static.